### PR TITLE
Memento Pattern: Fix function typo and function case

### DIFF
--- a/memento/caretaker.go
+++ b/memento/caretaker.go
@@ -8,6 +8,6 @@ func (c *caretaker) addMemento(m *memento) {
 	c.mementoArray = append(c.mementoArray, m)
 }
 
-func (c *caretaker) getMenento(index int) *memento {
+func (c *caretaker) getMemento(index int) *memento {
 	return c.mementoArray[index]
 }

--- a/memento/main.go
+++ b/memento/main.go
@@ -23,10 +23,10 @@ func main() {
 	fmt.Printf("Originator Current State: %s\n", originator.getState())
 	caretaker.addMemento(originator.createMemento())
 
-	originator.restorememento(caretaker.getMenento(1))
+	originator.restoreMemento(caretaker.getMemento(1))
 	fmt.Printf("Restored to State: %s\n", originator.getState())
 
-	originator.restorememento(caretaker.getMenento(0))
+	originator.restoreMemento(caretaker.getMemento(0))
 	fmt.Printf("Restored to State: %s\n", originator.getState())
 
 }

--- a/memento/originator.go
+++ b/memento/originator.go
@@ -8,7 +8,7 @@ func (e *originator) createMemento() *memento {
 	return &memento{state: e.state}
 }
 
-func (e *originator) restorememento(m *memento) {
+func (e *originator) restoreMemento(m *memento) {
 	e.state = m.getSavedState()
 }
 


### PR DESCRIPTION
- Fix typo in function `getMenento` to `getMemento`
- Update case to `camelCase` for `restoreMemento` function in order to match the case used in other functions