### PR TITLE
Use newNormalBuilder and newIglooBuilder functions

### DIFF
--- a/builder/iBuilder.go
+++ b/builder/iBuilder.go
@@ -9,11 +9,11 @@ type iBuilder interface {
 
 func getBuilder(builderType string) iBuilder {
 	if builderType == "normal" {
-		return &normalBuilder{}
+		return newNormalBuilder()
 	}
 
 	if builderType == "igloo" {
-		return &iglooBuilder{}
+		return newIglooBuilder()
 	}
 	return nil
 }


### PR DESCRIPTION
There are 2 functions you are not used to for some reason - [here](https://github.com/RefactoringGuru/design-patterns-go/blob/16aee4ac7cf01cdeccf61e9a0d1420f7c02051a3/builder/iBuilder.go#L12)

- [newIglooBuilder](https://github.com/RefactoringGuru/design-patterns-go/blob/16aee4ac7cf01cdeccf61e9a0d1420f7c02051a3/builder/iglooBuilder.go#L9)
- [newNormalBuilder](https://github.com/RefactoringGuru/design-patterns-go/blob/16aee4ac7cf01cdeccf61e9a0d1420f7c02051a3/builder/normalBuilder.go#L9) 

I think we need to start using or remove them at all

Thanks