### PR TITLE
Optimize the template method pattern, call genAndSendOTP function by concrete product class

### DIFF
--- a/template/main.go
+++ b/template/main.go
@@ -17,16 +17,16 @@ func main() {
 	// emailOTP.genAndSendOTP(emailOTP, 4)
 	// fmt.Scanln()
 	smsOTP := &Sms{}
-	o := Otp{
+	smsOTP.Otp = Otp{
 		iOtp: smsOTP,
 	}
-	o.genAndSendOTP(4)
+	smsOTP.genAndSendOTP(4)
 
 	fmt.Println("")
 	emailOTP := &Email{}
-	o = Otp{
+	emailOTP.Otp = Otp{
 		iOtp: emailOTP,
 	}
-	o.genAndSendOTP(4)
+	emailOTP.genAndSendOTP(4)
 
 }


### PR DESCRIPTION
Hello
When I was learning about the template method pattern from your book, I found that the code implemented by go might have a better way to call it, concrete's genAndSendOTP can use concrete instead of concrete template class or base class.  The way to call will better. 

> eg: smsOTP.genAndSendOTP(4) instead of o.genAndSendOTP(4)