### PR TITLE
Fix: Minor fix to Proxy pattern

### DIFF
--- a/proxy/nginx.go
+++ b/proxy/nginx.go
@@ -1,7 +1,7 @@
 package main
 
 type Nginx struct {
-	application       *Application
+	application       server
 	maxAllowedRequest int
 	rateLimiter       map[string]int
 }


### PR DESCRIPTION
Set the `application` type as the interface `server`

In the exiting code the interface `server` is unused.